### PR TITLE
Fix missing volatile qualifiers, clean up socket shutdown, add an error message

### DIFF
--- a/test/helloworld-udpclient/main.cpp
+++ b/test/helloworld-udpclient/main.cpp
@@ -135,7 +135,7 @@ protected:
     volatile bool received;
     volatile bool resolved;
     const uint16_t _udpTimePort;
-    uint32_t _time;
+    volatile uint32_t _time;
 
 protected:
     char _rxBuf[32];


### PR DESCRIPTION
Fix an issue with repeated runs raised by OOB testing.
- Some flags were not set to volatile.
- The application needs to keep sockets alive until the close sequence completes.
