### PR TITLE
Use `yotta` instead of `yt`

### DIFF
--- a/test/helloworld-tcpclient/README.md
+++ b/test/helloworld-tcpclient/README.md
@@ -38,14 +38,14 @@ It is possible to work around this problem by changing the source port number us
 
 4. Set the yotta target:
 
-	```
-	yotta target frdm-k64f-gcc
-	```
+    ```
+    $ yotta target frdm-k64f-gcc
+    ```
 
 5. Build the examples. This will take a long time if it is the first time that the examples have been built:
 
     ```
-    $ yt build
+    $ yotta build
     ```
 
 6. Copy `build/frdm-k64f-gcc/test/mbed-example-network-test-helloworld-tcpclient.bin` to your mbed board and wait until the LED next to the USB port stops blinking.

--- a/test/helloworld-udpclient/README.md
+++ b/test/helloworld-udpclient/README.md
@@ -31,9 +31,9 @@ To build and run this example the following requirements are necessary:
 
 4. Set the yotta target:
 	
-	```
-	yotta target frdm-k64f-gcc
-	```
+    ```
+    $ yotta target frdm-k64f-gcc
+    ```
 
 5. Build the examples. This will take a long time if it is the first time that the examples have been built:
 

--- a/test/helloworld-udpclient/README.md
+++ b/test/helloworld-udpclient/README.md
@@ -38,7 +38,7 @@ To build and run this example the following requirements are necessary:
 5. Build the examples. This will take a long time if it is the first time that the examples have been built:
 
     ```
-    $ yt build
+    $ yotta build
     ```
 
 6. Copy `build/frdm-k64f-gcc/test/mbed-example-network-test-helloworld-udpclient.bin` to your mbed board and wait until the LED next to the USB port stops blinking.


### PR DESCRIPTION
Making yotta instructions more consistent.