### PR TITLE
remove redundant includes

### DIFF
--- a/test/echo-tcpserver/main.cpp
+++ b/test/echo-tcpserver/main.cpp
@@ -28,10 +28,7 @@
 #include "sal-iface-eth/EthernetInterface.h"
 #include "sockets/TCPListener.h"
 #include "sal/socket_api.h"
-#include "mbed-drivers/Timer.h"
 #include "sal-stack-lwip/lwipv4_init.h"
-#include "minar/minar.h"
-#include "core-util/FunctionPointer.h"
 
 namespace {
     const int ECHO_SERVER_PORT = 7;

--- a/test/echo-udpserver/main.cpp
+++ b/test/echo-udpserver/main.cpp
@@ -19,7 +19,6 @@
 #include "sockets/UDPSocket.h"
 #include "sal-stack-lwip/lwipv4_init.h"
 #include "sal/socket_api.h"
-#include "minar/minar.h"
 
 namespace {
     const int ECHO_SERVER_PORT = 7;

--- a/test/helloworld-tcpclient/main.cpp
+++ b/test/helloworld-tcpclient/main.cpp
@@ -26,11 +26,7 @@
 #include "mbed-drivers/mbed.h"
 #include "sal-iface-eth/EthernetInterface.h"
 #include "sockets/TCPStream.h"
-#include "mbed-drivers/test_env.h"
-#include "minar/minar.h"
-
 #include "sal-stack-lwip/lwipv4_init.h"
-#include "core-util/FunctionPointer.h"
 
 namespace {
 const char *HTTP_SERVER_NAME = "developer.mbed.org";

--- a/test/helloworld-udpclient/main.cpp
+++ b/test/helloworld-udpclient/main.cpp
@@ -27,8 +27,6 @@
 #include "EthernetInterface.h"
 #include "sockets/UDPSocket.h"
 #include "mbed-drivers/test_env.h"
-#include "minar/minar.h"
-#include "core-util/FunctionPointer.h"
 
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
Several individual includes in the tests don't need to be
explicitly included any more, since something else pulls
them in already.

Signed-off-by: Andy Green andy.green@linaro.org
