### PR TITLE
Changed serial speed setting

### DIFF
--- a/module.json
+++ b/module.json
@@ -17,7 +17,7 @@
   ],
   "extraIncludes": [],
   "dependencies": {
-    "mbed-drivers": "~0.11.1",
+    "mbed-drivers": "~0.12.0",
     "sockets": "^1.0.0"
   },
   "targetDependencies": {},

--- a/test/echo-tcpserver/main.cpp
+++ b/test/echo-tcpserver/main.cpp
@@ -135,8 +135,7 @@ TCPEchoServer* pServer;
 void app_start(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
-    static Serial pc(USBTX, USBRX);
-    pc.baud(115200);
+    get_stdio_serial().baud(115200);
     eth.init(); //Use DHCP
     eth.connect();
     lwipv4_socket_init();

--- a/test/echo-udpserver/main.cpp
+++ b/test/echo-udpserver/main.cpp
@@ -84,6 +84,7 @@ UDPSocket *udpserver;
 void app_start (int argc, char *argv[]) {
     (void) argc;
     (void) argv;
+    get_stdio_serial().baud(115200);
     eth.init(); //Use DHCP
     eth.connect();
 

--- a/test/helloworld-tcpclient/main.cpp
+++ b/test/helloworld-tcpclient/main.cpp
@@ -214,8 +214,7 @@ HelloHTTP *hello;
 void app_start(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
-    static Serial pc(USBTX, USBRX);
-    pc.baud(115200);
+    get_stdio_serial().baud(115200);
     printf("{{start}}\r\n");
     /* Initialise with DHCP, connect, and start up the stack */
     eth.init();

--- a/test/helloworld-udpclient/main.cpp
+++ b/test/helloworld-udpclient/main.cpp
@@ -168,8 +168,7 @@ UDPGetTime *gt;
 void app_start(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
-    static Serial pc(USBTX, USBRX);
-    pc.baud(115200);
+    get_stdio_serial().baud(115200);
 
     printf("{{start}}\r\n");
     /* Initialise with DHCP, connect, and start up the stack */


### PR DESCRIPTION
The way to set the serial speed changed starting with mbed-drivers
0.12.0. This commit updates the code to use the new way of setting
the speed.
Also changed the baud to 115200 on 'echo-udpserver' to be consistent
with the other tests in this repository.