### PR TITLE
Migrating to greentea-client

### DIFF
--- a/test/helloworld-tcpclient/main.cpp
+++ b/test/helloworld-tcpclient/main.cpp
@@ -26,7 +26,7 @@
 #include "mbed-drivers/mbed.h"
 #include "sal-iface-eth/EthernetInterface.h"
 #include "sockets/TCPStream.h"
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
 #include "minar/minar.h"
 
 #include "sal-stack-lwip/lwipv4_init.h"

--- a/test/helloworld-udpclient/main.cpp
+++ b/test/helloworld-udpclient/main.cpp
@@ -26,7 +26,7 @@
 #include "mbed-drivers/mbed.h"
 #include "EthernetInterface.h"
 #include "sockets/UDPSocket.h"
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
 #include "minar/minar.h"
 #include "core-util/FunctionPointer.h"
 
@@ -100,7 +100,7 @@ protected:
         /* A failure on send is a fatal error in this example */
         if (err != SOCKET_ERROR_NONE) {
             printf("Socket Error %d\r\n", err);
-            notify_completion(false);
+            GREENTEA_TESTSUITE_RESULT(false);
         }
     }
     /**
@@ -137,7 +137,7 @@ protected:
         /* A failure on recv is a fatal error in this example */
         if (err != SOCKET_ERROR_NONE) {
             printf("Socket Error %d\r\n", err);
-            notify_completion(false);
+            GREENTEA_TESTSUITE_RESULT(false);
         }
         uint32_t time;
         /* Correct for possible non 32-bit alignment */


### PR DESCRIPTION
The tcp and udp client tests are using the test_env from mbed-drivers, which leads to the following compiler warning:

```
#warning mbed-drivers/test_env.h is deprecated. Please use greentea-client/test_env.h instead.
```

I switched over the tests to use greentea-client.
